### PR TITLE
Fix wound removal to delete one copy

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -814,7 +814,7 @@ func _apply_card_effect(card_id: String) -> void:
 		"slow":
 			volley_ball_speed_multiplier = 0.7
 		"wound":
-			deck_manager.remove_card_from_all("wound", true)
+			deck_manager.remove_card_from_deck("wound")
 			info_label.text = "Wound removed from your deck."
 		_:
 			pass

--- a/scripts/managers/DeckManager.gd
+++ b/scripts/managers/DeckManager.gd
@@ -59,6 +59,10 @@ func remove_card_from_all(card_id: String, remove_from_deck: bool = true) -> voi
 	_emit_hand_changed()
 	_emit_piles_changed()
 
+func remove_card_from_deck(card_id: String) -> void:
+	_remove_one_from_array(deck, card_id)
+	_emit_piles_changed()
+
 func play_card(card_id: String) -> void:
 	hand.erase(card_id)
 	_emit_hand_changed()


### PR DESCRIPTION
## Summary
 - remove only the played Wound from the deck
 - avoid deleting other Wound copies in draw/discard piles

Closes #25