### PR TITLE
Extract roll variants into per-encounter policies

### DIFF
--- a/scripts/data/VariantPolicy.gd
+++ b/scripts/data/VariantPolicy.gd
@@ -3,6 +3,7 @@ class_name VariantPolicy
 
 @export var shield_chance: float = 0.1
 @export var regen_chance: float = 0.1
+@export var regen_amount: int = 1
 @export var curse_chance: float = 0.08
 
 func roll_variants() -> Dictionary:
@@ -13,7 +14,7 @@ func roll_variants() -> Dictionary:
 		data["shielded_sides"] = [sides[0]]
 	if randf() < regen_chance:
 		data["regen_on_drop"] = true
-		data["regen_amount"] = 1
+		data["regen_amount"] = regen_amount
 	if randf() < curse_chance:
 		data["is_cursed"] = true
 	return data

--- a/scripts/managers/EncounterManager.gd
+++ b/scripts/managers/EncounterManager.gd
@@ -159,10 +159,10 @@ func _roll_speed_boost(floor_index: int, is_boss: bool) -> bool:
 
 func _variant_policy_for_floor(floor_index: int, is_elite: bool, is_boss: bool) -> VariantPolicy:
 	if is_boss:
-		return boss_variant_policy
+		return boss_variant_policy.duplicate() as VariantPolicy
 	if floor_index >= 3 or is_elite:
-		return elite_variant_policy
-	return normal_variant_policy
+		return elite_variant_policy.duplicate() as VariantPolicy
+	return normal_variant_policy.duplicate() as VariantPolicy
 
 func _build_fallback_config(floor_index: int, is_elite: bool, is_boss: bool) -> EncounterConfig:
 	var config := EncounterConfig.new()


### PR DESCRIPTION
## Summary
- move variant rolling onto VariantPolicy
- introduce normal/elite/boss policy defaults in EncounterManager
- keep encounter configs selecting policies via _variant_policy_for_floor

Closes #20