### PR TITLE
Refactor UI panel transitions and counts

### DIFF
--- a/data/floor_plans/basic.tres
+++ b/data/floor_plans/basic.tres
@@ -1,54 +1,44 @@
-[gd_resource type="Resource" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="FloorPlan" load_steps=2 format=3 uid="uid://i7lhqa4cfe6v"]
 
-[ext_resource type="Script" path="res://scripts/data/FloorPlan.gd" id=1]
+[ext_resource type="Script" uid="uid://bais46vupi66j" path="res://scripts/data/FloorPlan.gd" id="1"]
 
 [resource]
 script = ExtResource("1")
+rooms = Array[Dictionary]([{
+"id": "start",
+"next": ["c1", "c2"],
+"type": "combat"
+}, {
+"id": "c1",
+"next": ["r1", "e1"],
+"type": "combat"
+}, {
+"id": "c2",
+"next": ["s1", "c3"],
+"type": "combat"
+}, {
+"id": "r1",
+"next": ["c3"],
+"type": "rest"
+}, {
+"id": "e1",
+"next": ["c3"],
+"type": "elite"
+}, {
+"id": "s1",
+"next": ["c3"],
+"type": "shop"
+}, {
+"id": "c3",
+"next": ["boss"],
+"type": "combat"
+}, {
+"id": "boss",
+"next": ["victory"],
+"type": "boss"
+}, {
+"id": "victory",
+"next": [],
+"type": "victory"
+}])
 start_room_id = "start"
-rooms = [
-	{
-		"id": "start",
-		"type": "combat",
-		"next": ["c1", "c2"]
-	},
-	{
-		"id": "c1",
-		"type": "combat",
-		"next": ["r1", "e1"]
-	},
-	{
-		"id": "c2",
-		"type": "combat",
-		"next": ["s1", "c3"]
-	},
-	{
-		"id": "r1",
-		"type": "rest",
-		"next": ["c3"]
-	},
-	{
-		"id": "e1",
-		"type": "elite",
-		"next": ["c3"]
-	},
-	{
-		"id": "s1",
-		"type": "shop",
-		"next": ["c3"]
-	},
-	{
-		"id": "c3",
-		"type": "combat",
-		"next": ["boss"]
-	},
-	{
-		"id": "boss",
-		"type": "boss",
-		"next": ["victory"]
-	},
-	{
-		"id": "victory",
-		"type": "victory",
-		"next": []
-	}
-]

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -169,21 +169,6 @@ offset_right = 114.0
 offset_bottom = 158.0
 color = Color(0.24, 0.24, 0.24, 1)
 
-[node name="DeckCountLabel" type="Label" parent="HUD/HandBar/DeckStack"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -2.0
-offset_top = 50.0
-offset_right = -2.0
-offset_bottom = 100.0
-grow_horizontal = 2
-grow_vertical = 2
-text = "0"
-horizontal_alignment = 1
-vertical_alignment = 1
-
 [node name="DeckButton" type="Button" parent="HUD/HandBar/DeckStack"]
 layout_mode = 1
 anchors_preset = 15
@@ -243,21 +228,6 @@ offset_top = 12.0
 offset_right = 122.0
 offset_bottom = 166.0
 color = Color(0.23921569, 0.23921569, 0.23921569, 1)
-
-[node name="DiscardCountLabel" type="Label" parent="HUD/HandBar/DiscardStack"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -2.0
-offset_top = -9.0
-offset_right = -2.0
-offset_bottom = 3.0
-grow_horizontal = 2
-grow_vertical = 2
-text = "0"
-horizontal_alignment = 1
-vertical_alignment = 1
 
 [node name="DiscardButton" type="Button" parent="HUD/HandBar/DiscardStack"]
 layout_mode = 1

--- a/scripts/managers/HudController.gd
+++ b/scripts/managers/HudController.gd
@@ -3,9 +3,9 @@ class_name HudController
 
 var energy_label: Label
 var deck_label: Label
-var deck_count_label: Label
 var discard_label: Label
-var discard_count_label: Label
+var deck_button: Button
+var discard_button: Button
 var hp_label: Label
 var gold_label: Label
 var shop_gold_label: Label
@@ -28,9 +28,9 @@ var card_art_textures: Dictionary = {}
 func setup(hud_nodes: Dictionary, data: Dictionary, type_colors: Dictionary, button_size: Vector2, art_textures: Dictionary) -> void:
 	energy_label = hud_nodes.get("energy_label")
 	deck_label = hud_nodes.get("deck_label")
-	deck_count_label = hud_nodes.get("deck_count_label")
 	discard_label = hud_nodes.get("discard_label")
-	discard_count_label = hud_nodes.get("discard_count_label")
+	deck_button = hud_nodes.get("deck_button")
+	discard_button = hud_nodes.get("discard_button")
 	hp_label = hud_nodes.get("hp_label")
 	gold_label = hud_nodes.get("gold_label")
 	shop_gold_label = hud_nodes.get("shop_gold_label")
@@ -64,12 +64,12 @@ func update_labels(energy: int, max_energy: int, draw_count: int, discard_count:
 		energy_label.text = "Energy: %d/%d" % [energy, max_energy]
 	if deck_label:
 		deck_label.text = "Draw: %d" % draw_count
-	if deck_count_label:
-		deck_count_label.text = "%d" % draw_count
 	if discard_label:
 		discard_label.text = "Discard: %d" % discard_count
-	if discard_count_label:
-		discard_count_label.text = "%d" % discard_count
+	if deck_button:
+		deck_button.text = "%d" % draw_count
+	if discard_button:
+		discard_button.text = "%d" % discard_count
 	if hp_label:
 		hp_label.text = "HP: %d/%d" % [hp, max_hp]
 	if gold_label:


### PR DESCRIPTION
## Summary
- centralize panel swap + deck return context logic
- show deck/discard counts directly on stack buttons
- update HUD wiring for counts

## Notes
- includes Godot serialization-only update to data/floor_plans/basic.tres

## Testing
- manual (user)

Refs #10