### PR TITLE
Keep persist checkbox style separate

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -116,6 +116,7 @@ offset_bottom = 186.0
 theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 1
+tooltip_text = "Re-apply after use (while available)."
 text = "Persist"
 
 [node name="InfoLabel" type="Label" parent="HUD"]

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -299,8 +299,6 @@ func _set_hud_tooltips() -> void:
 	floor_label.tooltip_text = "Current room in the run."
 	info_label.mouse_filter = Control.MOUSE_FILTER_STOP
 	info_label.tooltip_text = "Status and prompts for the current room."
-	if mods_persist_checkbox:
-		mods_persist_checkbox.tooltip_text = "Re-apply after use (while available)."
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel"):


### PR DESCRIPTION
Removes flow updates from _apply_persist_checkbox_style and moves the message to a checkbox tooltip.

Closes #13.