### PR TITLE
Add shop card reroll

### DIFF
--- a/data/balance/basic.tres
+++ b/data/balance/basic.tres
@@ -103,3 +103,5 @@ shop_upgrade_hand_bonus = 1
 shop_vitality_price = 60
 shop_vitality_max_hp_bonus = 10
 shop_vitality_heal = 10
+shop_reroll_base_price = 20
+shop_reroll_multiplier = 1.8

--- a/scripts/data/BalanceData.gd
+++ b/scripts/data/BalanceData.gd
@@ -16,3 +16,5 @@ class_name BalanceData
 @export var shop_vitality_price: int = 60
 @export var shop_vitality_max_hp_bonus: int = 10
 @export var shop_vitality_heal: int = 10
+@export var shop_reroll_base_price: int = 20
+@export var shop_reroll_multiplier: float = 1.8


### PR DESCRIPTION
## Summary
- add a shop reroll button that refreshes only card offers and shows the current price
- make reroll cost exponential per shop visit using new balance settings

## Testing
- not run (local)

Closes #50
