### PR TITLE
Reset deck between floors and add bounce SFX

### DIFF
--- a/scenes/Ball.tscn
+++ b/scenes/Ball.tscn
@@ -15,3 +15,6 @@ shape = SubResource("1")
 position = Vector2(-8, -8)
 size = Vector2(16, 16)
 color = Color(0.95, 0.95, 1, 1)
+
+[node name="BounceSfx" type="AudioStreamPlayer" parent="."]
+volume_db = -8.0

--- a/scenes/BounceBall.tscn
+++ b/scenes/BounceBall.tscn
@@ -15,3 +15,6 @@ shape = SubResource("1")
 position = Vector2(-8, -8)
 size = Vector2(16, 16)
 color = Color(0.95, 0.95, 1, 1)
+
+[node name="BounceSfx" type="AudioStreamPlayer" parent="."]
+volume_db = -8.0

--- a/scripts/BounceBall.gd.uid
+++ b/scripts/BounceBall.gd.uid
@@ -1,0 +1,1 @@
+uid://dr7xi7hf6veob

--- a/scripts/Brick.gd
+++ b/scripts/Brick.gd
@@ -23,7 +23,6 @@ var regen_amount: int = 1
 var is_cursed: bool = false
 var suppress_curse_on_destroy: bool = false
 var particle_rng: RandomNumberGenerator = RandomNumberGenerator.new()
-
 func _ready() -> void:
 	particle_rng.randomize()
 
@@ -126,6 +125,8 @@ func _spawn_hit_particles(count: int) -> void:
 	var parent_node := get_parent()
 	if parent_node == null:
 		return
+	if count <= 0:
+		return
 	for _i in range(count):
 		var particle := HIT_PARTICLE_SCENE.instantiate()
 		if particle == null:
@@ -141,7 +142,7 @@ func _spawn_hit_particles(count: int) -> void:
 		if particle.has_method("setup"):
 			var velocity := Vector2(
 				particle_rng.randf_range(-120.0, 120.0),
-				particle_rng.randf_range(-320.0, -140.0)
+				particle_rng.randf_range(-320.0, 120.0)
 			)
 			particle.call("setup", rect.color, velocity)
 
@@ -170,7 +171,7 @@ func _spawn_bounce_particle() -> void:
 		particle.set("paddle_path_override", "Paddle")
 
 func _damage_particle_count(damage: int) -> int:
-	return clamp(6 + damage * 2, 6, 36)
+	return clamp(3 + damage, 3, 18)
 
 func _destroy_particle_count(damage: int) -> int:
-	return clamp(12 + damage * 4, 12, 60)
+	return clamp(6 + damage * 2, 6, 30)

--- a/scripts/Graphics.gd
+++ b/scripts/Graphics.gd
@@ -129,4 +129,5 @@ func _apply_content_scale() -> void:
 		var root := get_tree().root
 		root.content_scale_mode = Window.CONTENT_SCALE_MODE_CANVAS_ITEMS
 		root.content_scale_aspect = Window.CONTENT_SCALE_ASPECT_EXPAND
+		App.refresh_layout_cache()
 		root.content_scale_size = Vector2(App.get_layout_resolution())

--- a/scripts/HitParticle.gd
+++ b/scripts/HitParticle.gd
@@ -1,27 +1,52 @@
 extends Node2D
 
+const DEFAULT_MAX_SPEED: float = 320.0
+
 @onready var rect: ColorRect = $Rect
 
 var velocity: Vector2 = Vector2.ZERO
 var gravity: float = 700.0
 var lifetime: float = 0.0
-var max_speed: float = 320.0
+var age: float = 0.0
+var max_speed: float = DEFAULT_MAX_SPEED
+var max_speed_sq: float = DEFAULT_MAX_SPEED * DEFAULT_MAX_SPEED
+var base_color: Color = Color(1, 1, 1, 1)
+var long_life_chance: float = 0.08
+var short_life_range: Vector2 = Vector2(0.5, 2.0)
+var long_life_range: Vector2 = Vector2(1.2, 4.0)
 
 func setup(color: Color, initial_velocity: Vector2) -> void:
+	if rect == null:
+		rect = get_node_or_null("Rect") as ColorRect
+	base_color = color
 	if rect:
 		rect.color = color
 	velocity = _clamp_velocity(initial_velocity)
+	age = 0.0
+	var rng := RandomNumberGenerator.new()
+	rng.randomize()
+	if rng.randf() < long_life_chance:
+		lifetime = rng.randf_range(long_life_range.x, long_life_range.y)
+	else:
+		lifetime = rng.randf_range(short_life_range.x, short_life_range.y)
 
 func _process(delta: float) -> void:
+	age += delta
+	if lifetime > 0.0:
+		var t: float = clamp(age / lifetime, 0.0, 1.0)
+		if rect:
+			var c := base_color
+			c.a *= 1.0 - t
+			rect.color = c
 	velocity.y += gravity * delta
 	velocity = _clamp_velocity(velocity)
 	position += velocity * delta
 	var screen := App.get_layout_size()
-	if global_position.y > screen.y + 100.0:
+	if age >= lifetime or global_position.y > screen.y + 100.0:
 		queue_free()
 
 func _clamp_velocity(value: Vector2) -> Vector2:
-	var speed := value.length()
-	if speed <= max_speed or speed == 0.0:
+	var speed_sq := value.length_squared()
+	if speed_sq <= max_speed_sq or speed_sq == 0.0:
 		return value
 	return value.normalized() * max_speed

--- a/scripts/HitParticle.gd.uid
+++ b/scripts/HitParticle.gd.uid
@@ -1,0 +1,1 @@
+uid://bv03mlql1env

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -621,6 +621,7 @@ func _start_encounter(is_elite: bool) -> void:
 	hud_controller.hide_all_panels()
 	info_label.text = "Plan your volley, then launch."
 	_clear_active_balls()
+	_reset_deck_for_next_floor()
 	current_is_boss = false
 	var config := encounter_manager.build_config_from_floor(floor_index, is_elite, false)
 	current_pattern = config.pattern_id
@@ -639,6 +640,7 @@ func _start_boss() -> void:
 	hud_controller.hide_all_panels()
 	info_label.text = "Boss fight. Plan carefully."
 	_clear_active_balls()
+	_reset_deck_for_next_floor()
 	current_is_boss = true
 	var config := encounter_manager.build_config_from_floor(floor_index, false, true)
 	current_pattern = config.pattern_id
@@ -781,11 +783,18 @@ func _on_ball_mod_consumed(mod_id: String) -> void:
 func _end_encounter() -> void:
 	hud_controller.hide_all_panels()
 	_clear_active_balls()
+	_reset_deck_for_next_floor()
 	if current_is_boss:
 		_show_victory()
 		return
 	gold += 25
 	_show_reward_panel()
+
+func _reset_deck_for_next_floor() -> void:
+	if deck_manager:
+		deck_manager.reset_piles()
+	_refresh_hand()
+	_update_labels()
 
 func _build_reward_buttons() -> void:
 	_build_combat_reward_buttons()

--- a/scripts/managers/DeckManager.gd
+++ b/scripts/managers/DeckManager.gd
@@ -28,6 +28,14 @@ func setup(starting_deck: Array[String]) -> void:
 	_emit_piles_changed()
 	_emit_hand_changed()
 
+func reset_piles() -> void:
+	draw_pile = deck.duplicate()
+	discard_pile.clear()
+	hand.clear()
+	_shuffle_array(draw_pile)
+	_emit_piles_changed()
+	_emit_hand_changed()
+
 func draw_cards(count: int) -> void:
 	for _i in range(count):
 		if hand.size() >= MAX_HAND_SIZE:


### PR DESCRIPTION
## Summary
- procedural bounce SFX for all ball collisions
- hit particle fade-out and optimize particle speed calculations while keeping counts lower for performance
- cache layout size/resolution and refresh on window resize to reduce hot calls
- reset deck piles/hand between floors

## Testing
- not run (local)
