### PR TITLE
Hide Test Lab and shrink debug UI

### DIFF
--- a/scenes/TestLab.tscn
+++ b/scenes/TestLab.tscn
@@ -32,7 +32,7 @@ offset_left = 10.0
 offset_top = 10.0
 offset_right = -10.0
 offset_bottom = -10.0
-theme_override_constants/separation = 6
+theme_override_constants/separation = 4
 
 [node name="Title" type="Label" parent="DebugPanel/VBox"]
 layout_mode = 2

--- a/scripts/MainMenu.gd
+++ b/scripts/MainMenu.gd
@@ -11,6 +11,7 @@ extends Control
 @onready var seed_status: Label = $SeedDialog/SeedDialogPanel/SeedStatus
 
 var suppress_seed_validation: bool = false
+var test_lab_unlocked: bool = false
 
 func _ready() -> void:
 	start_button.pressed.connect(_open_seed_dialog)
@@ -28,12 +29,30 @@ func _ready() -> void:
 			ok_button.pressed.connect(_start_game)
 	if seed_input:
 		seed_input.text_changed.connect(_on_seed_text_changed)
+	_lock_test_lab()
 	_update_continue_button()
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel") and App.has_run():
 		App.continue_run()
 		get_viewport().set_input_as_handled()
+		return
+	if event is InputEventKey:
+		_try_unlock_test_lab(event as InputEventKey)
+
+func _lock_test_lab() -> void:
+	test_lab_unlocked = false
+	if test_button:
+		test_button.visible = false
+
+func _try_unlock_test_lab(event: InputEventKey) -> void:
+	if test_lab_unlocked or test_button == null:
+		return
+	if not event.pressed or event.echo:
+		return
+	if event.keycode == KEY_T and event.alt_pressed and event.ctrl_pressed and event.shift_pressed:
+		test_lab_unlocked = true
+		test_button.visible = true
 
 func _open_seed_dialog() -> void:
 	if seed_dialog == null:

--- a/scripts/TestLab.gd
+++ b/scripts/TestLab.gd
@@ -3,7 +3,7 @@ extends Control
 @onready var main: Node = $Main
 
 func _ready() -> void:
-	_apply_debug_font_size(10)
+	_apply_debug_font_size(9)
 	_connect_button("DebugPanel/VBox/StartCombat", func() -> void:
 		main.floor_index = 1
 		main._start_encounter(false)


### PR DESCRIPTION
## Summary
- hide the Test Lab button behind a modifier key combo
- reduce Test Lab debug button font size by one

## Testing
- not run (UI-only)
