### PR TITLE
Exclude special buttons from global theme

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -834,12 +834,20 @@ func _apply_hud_theme() -> void:
 	if theme == null:
 		return
 	_apply_theme_recursive(hud, theme)
+	_clear_hud_theme_exceptions()
 
 func _apply_theme_recursive(node: Node, theme: Theme) -> void:
 	if node is Control:
 		(node as Control).theme = theme
 	for child in node.get_children():
 		_apply_theme_recursive(child, theme)
+
+func _clear_hud_theme_exceptions() -> void:
+	var blank := Theme.new()
+	if deck_button:
+		deck_button.theme = blank
+	if discard_button:
+		discard_button.theme = blank
 
 func _show_treasure() -> void:
 	_show_treasure_panel()

--- a/scripts/TestLab.gd
+++ b/scripts/TestLab.gd
@@ -4,6 +4,7 @@ extends Control
 
 func _ready() -> void:
 	_apply_debug_font_size(9)
+	_apply_debug_theme()
 	_connect_button("DebugPanel/VBox/StartCombat", func() -> void:
 		main.floor_index = 1
 		main._start_encounter(false)
@@ -88,6 +89,12 @@ func _apply_debug_font_size(size: int) -> void:
 	for child in container.get_children():
 		if child is Control:
 			(child as Control).add_theme_font_size_override("font_size", size)
+
+func _apply_debug_theme() -> void:
+	var panel := get_node("DebugPanel") as Control
+	if panel == null:
+		return
+	panel.theme = Theme.new()
 
 func _connect_button(path: String, action: Callable) -> void:
 	var button := get_node(path) as Button


### PR DESCRIPTION
## Summary
- Keep deck/discard buttons from inheriting the global theme so their card-stack styling stays intact
- Apply a local debug theme to Test Lab controls to keep them visually distinct from the main UI

## Testing
- Not run (requires Godot)