### PR TITLE
Match button palette to bricks

### DIFF
--- a/themes/ui_theme.tres
+++ b/themes/ui_theme.tres
@@ -12,21 +12,21 @@ content_margin_left = 10.0
 content_margin_top = 6.0
 content_margin_right = 10.0
 content_margin_bottom = 6.0
-bg_color = Color(0.18, 0.18, 0.22, 1)
+bg_color = Color(0.95, 0.6, 0.2, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_gfhtu"]
 content_margin_left = 10.0
 content_margin_top = 6.0
 content_margin_right = 10.0
 content_margin_bottom = 6.0
-bg_color = Color(0.14, 0.14, 0.16, 1)
+bg_color = Color(0.86, 0.32, 0.26, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qa7hf"]
 content_margin_left = 10.0
 content_margin_top = 6.0
 content_margin_right = 10.0
 content_margin_bottom = 6.0
-bg_color = Color(0.25, 0.2, 0.12, 1)
+bg_color = Color(0.95, 0.85, 0.25, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jkgan"]
 content_margin_left = 8.0
@@ -40,7 +40,7 @@ default_font_size = 14
 Button/colors/font_color = Color(0.96, 0.96, 0.98, 1)
 Button/colors/font_disabled_color = Color(0.6, 0.6, 0.65, 1)
 Button/colors/font_hover_color = Color(1, 1, 1, 1)
-Button/colors/font_pressed_color = Color(1, 1, 1, 1)
+Button/colors/font_pressed_color = Color(0.1, 0.1, 0.1, 1)
 Button/styles/disabled = SubResource("StyleBoxFlat_pgyi5")
 Button/styles/hover = SubResource("StyleBoxFlat_xxbg1")
 Button/styles/normal = SubResource("StyleBoxFlat_gfhtu")


### PR DESCRIPTION
## Summary
- Use brick palette colors for button normal/hover/pressed backgrounds in the global UI theme
- Darken pressed text for contrast on the bright yellow state

## Testing
- Not run (requires Godot)