### PR TITLE
Exclude special buttons from palette theme

### DIFF
--- a/scripts/App.gd
+++ b/scripts/App.gd
@@ -8,6 +8,9 @@ const TEST_SCENE: PackedScene = preload("res://scenes/TestLab.tscn")
 const SETTINGS_PATH: String = "user://settings.cfg"
 const FALLBACK_BASE_RESOLUTION: Vector2i = Vector2i(800, 600)
 const UI_SCALE: float = 0.75
+const NEUTRAL_BUTTON_NORMAL: Color = Color(0.14, 0.14, 0.16)
+const NEUTRAL_BUTTON_HOVER: Color = Color(0.18, 0.18, 0.22)
+const NEUTRAL_BUTTON_PRESSED: Color = Color(0.12, 0.12, 0.14)
 
 var menu_instance: Node = null
 var run_instance: Node = null
@@ -150,6 +153,22 @@ func _apply_global_theme() -> void:
 
 func get_global_theme() -> Theme:
 	return _global_theme
+
+func apply_neutral_button_style(button: BaseButton) -> void:
+	if button == null:
+		return
+	button.add_theme_stylebox_override("normal", _make_button_box(NEUTRAL_BUTTON_NORMAL))
+	button.add_theme_stylebox_override("hover", _make_button_box(NEUTRAL_BUTTON_HOVER))
+	button.add_theme_stylebox_override("pressed", _make_button_box(NEUTRAL_BUTTON_PRESSED))
+
+func _make_button_box(color: Color) -> StyleBoxFlat:
+	var box := StyleBoxFlat.new()
+	box.bg_color = color
+	box.content_margin_left = 10
+	box.content_margin_top = 6
+	box.content_margin_right = 10
+	box.content_margin_bottom = 6
+	return box
 
 func get_base_resolution() -> Vector2i:
 	var width: int = int(ProjectSettings.get_setting(

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -834,12 +834,17 @@ func _apply_hud_theme() -> void:
 	if theme == null:
 		return
 	_apply_theme_recursive(hud, theme)
+	_apply_hud_button_exclusions()
 
 func _apply_theme_recursive(node: Node, theme: Theme) -> void:
 	if node is Control:
 		(node as Control).theme = theme
 	for child in node.get_children():
 		_apply_theme_recursive(child, theme)
+
+func _apply_hud_button_exclusions() -> void:
+	if mods_persist_checkbox:
+		App.apply_neutral_button_style(mods_persist_checkbox)
 
 func _show_treasure() -> void:
 	_show_treasure_panel()
@@ -890,12 +895,14 @@ func _build_shop_card_buttons() -> void:
 		else:
 			info_label.text = "Cannot remove."
 	)
+	App.apply_neutral_button_style(remove)
 	shop_cards_buttons.add_child(remove)
 	var reroll := Button.new()
 	reroll.text = "Reroll Cards (%dg)" % _shop_reroll_price()
 	reroll.pressed.connect(func() -> void:
 		_reroll_shop_cards()
 	)
+	App.apply_neutral_button_style(reroll)
 	shop_cards_buttons.add_child(reroll)
 
 func _clear_shop_card_buttons() -> void:
@@ -916,6 +923,7 @@ func _build_shop_buff_buttons() -> void:
 		else:
 			info_label.text = "Not enough gold."
 	)
+	App.apply_neutral_button_style(upgrade)
 	shop_buffs_buttons.add_child(upgrade)
 
 	var vitality_buff := Button.new()
@@ -934,6 +942,7 @@ func _build_shop_buff_buttons() -> void:
 		else:
 			info_label.text = "Not enough gold."
 	)
+	App.apply_neutral_button_style(vitality_buff)
 	shop_buffs_buttons.add_child(vitality_buff)
 
 func _build_shop_mod_buttons() -> void:
@@ -962,6 +971,7 @@ func _build_shop_mod_buttons() -> void:
 			else:
 				info_label.text = "Not enough gold."
 		)
+		App.apply_neutral_button_style(button)
 		shop_ball_mods_buttons.add_child(button)
 
 func _reset_shop_offers() -> void:
@@ -1342,6 +1352,7 @@ func _refresh_mod_buttons() -> void:
 		button.pressed.connect(func() -> void:
 			_select_ball_mod(active_mod_id)
 		)
+		App.apply_neutral_button_style(button)
 		mods_buttons.add_child(button)
 	var clear_button := Button.new()
 	clear_button.text = "Clear"

--- a/scripts/managers/HudController.gd
+++ b/scripts/managers/HudController.gd
@@ -120,6 +120,7 @@ func create_card_button(card_id: String) -> Button:
 	button.text = ""
 	button.tooltip_text = _card_tooltip(card_id)
 	button.clip_text = false
+	App.apply_neutral_button_style(button)
 	_apply_card_style(button, card_id)
 	_apply_card_button_size(button)
 	_wire_hand_hover(button)

--- a/themes/ui_theme.tres
+++ b/themes/ui_theme.tres
@@ -12,21 +12,21 @@ content_margin_left = 10.0
 content_margin_top = 6.0
 content_margin_right = 10.0
 content_margin_bottom = 6.0
-bg_color = Color(0.18, 0.18, 0.22, 1)
+bg_color = Color(0.64, 0.4, 0.76, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_gfhtu"]
 content_margin_left = 10.0
 content_margin_top = 6.0
 content_margin_right = 10.0
 content_margin_bottom = 6.0
-bg_color = Color(0.14, 0.14, 0.16, 1)
+bg_color = Color(0.72, 0.46, 0.86, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qa7hf"]
 content_margin_left = 10.0
 content_margin_top = 6.0
 content_margin_right = 10.0
 content_margin_bottom = 6.0
-bg_color = Color(0.25, 0.2, 0.12, 1)
+bg_color = Color(0.56, 0.35, 0.67, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jkgan"]
 content_margin_left = 8.0


### PR DESCRIPTION
## Summary
- Switch the global button default to purple
- Keep card buttons and mod buttons on neutral styling while preserving their self-modulate colors
- Keep shop purchase buttons and the persist checkbox on neutral styling

## Testing
- Not run (requires Godot)