### PR TITLE
Add volley prompt and input tweaks

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -34,6 +34,7 @@ stretch/aspect="expand"
 
 [gui]
 
+timers/tooltip_delay_sec=0.25
 theme/custom="res://themes/ui_theme.tres"
 
 [physics]

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -132,6 +132,21 @@ offset_right = -16.0
 offset_bottom = 62.0
 text = "Choose your next room."
 
+[node name="VolleyPromptLabel" type="RichTextLabel" parent="HUD"]
+anchors_preset = 10
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -220.0
+offset_right = 220.0
+custom_minimum_size = Vector2(360, 0)
+mouse_filter = 2
+bbcode_enabled = true
+fit_content = true
+autowrap_mode = 0
+horizontal_alignment = 1
+text = "Press [b]Spacebar[/b] to start your volley..."
+visible = false
+
 [node name="VictoryOverlay" type="ColorRect" parent="HUD"]
 visible = false
 z_index = -1

--- a/scripts/App.gd
+++ b/scripts/App.gd
@@ -40,6 +40,7 @@ var _settings_paddle_speed_multiplier: float = 1.0
 
 func _ready() -> void:
 	_ui_particle_rng.randomize()
+	_ensure_paddle_keyboard_inputs()
 	_apply_global_theme()
 	_apply_saved_settings()
 	_refresh_layout_cache()
@@ -47,6 +48,25 @@ func _ready() -> void:
 	var current: Node = get_tree().current_scene
 	if current and current.scene_file_path == "res://scenes/MainMenu.tscn":
 		menu_instance = current
+
+func _ensure_paddle_keyboard_inputs() -> void:
+	_ensure_action_key("ui_left", KEY_A)
+	_ensure_action_key("ui_right", KEY_D)
+
+func _ensure_action_key(action: String, keycode: int) -> void:
+	if not InputMap.has_action(action):
+		InputMap.add_action(action)
+	if _action_has_key(action, keycode):
+		return
+	var event := InputEventKey.new()
+	event.keycode = keycode
+	InputMap.action_add_event(action, event)
+
+func _action_has_key(action: String, keycode: int) -> bool:
+	for event in InputMap.action_get_events(action):
+		if event is InputEventKey and (event as InputEventKey).keycode == keycode:
+			return true
+	return false
 
 func has_run() -> bool:
 	return run_instance != null and is_instance_valid(run_instance)

--- a/scripts/MainMenu.gd
+++ b/scripts/MainMenu.gd
@@ -42,6 +42,10 @@ func _ready() -> void:
 	_update_continue_button()
 	App.bind_button_feedback(self)
 
+func _input(event: InputEvent) -> void:
+	if event is InputEventMouseMotion:
+		Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel") and App.has_run():
 		App.continue_run()


### PR DESCRIPTION
## Summary
- add a pulsing pre-volley prompt centered above the paddle
- support A/D as paddle movement keys at runtime
- show the mouse cursor on menu movement and shorten tooltip delay

## Testing
- not run (not requested)