### PR TITLE
Simplify encounter setup flow

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -717,38 +717,27 @@ func _reveal_mystery_room() -> String:
 	return revealed
 
 func _start_encounter(is_elite: bool) -> void:
-	state = GameState.PLANNING
-	_hide_all_panels()
-	info_label.text = "Plan your volley, then launch."
-	_clear_active_balls()
-	_reset_deck_for_next_floor()
-	current_is_boss = false
-	var config := encounter_manager.build_config_from_floor(floor_index, is_elite, false)
-	current_pattern = config.pattern_id
-	encounter_speed_boost = config.speed_boost
-	encounter_rows = config.rows
-	encounter_cols = config.cols
-	encounter_hp = config.base_hp
-	encounter_base_threat = config.base_threat
-	if encounter_speed_boost:
-		info_label.text = "Volley Mod: Speed Boost."
-	encounter_manager.start_encounter(config, Callable(self, "_on_brick_destroyed"), Callable(self, "_on_brick_damaged"))
-	_start_turn()
+	_begin_encounter(is_elite, false, "Plan your volley, then launch.")
 
 func _start_boss() -> void:
+	_begin_encounter(false, true, "Boss fight. Plan carefully.")
+
+func _begin_encounter(is_elite: bool, is_boss: bool, intro_text: String) -> void:
 	state = GameState.PLANNING
 	_hide_all_panels()
-	info_label.text = "Boss fight. Plan carefully."
+	info_label.text = intro_text
 	_clear_active_balls()
 	_reset_deck_for_next_floor()
-	current_is_boss = true
-	var config := encounter_manager.build_config_from_floor(floor_index, false, true)
+	current_is_boss = is_boss
+	var config := encounter_manager.build_config_from_floor(floor_index, is_elite, is_boss)
 	current_pattern = config.pattern_id
 	encounter_speed_boost = config.speed_boost
 	encounter_rows = config.rows
 	encounter_cols = config.cols
 	encounter_hp = config.base_hp
 	encounter_base_threat = config.base_threat
+	if encounter_speed_boost and not is_boss:
+		info_label.text = "Volley Mod: Speed Boost."
 	encounter_manager.start_encounter(config, Callable(self, "_on_brick_destroyed"), Callable(self, "_on_brick_damaged"))
 	_start_turn()
 

--- a/scripts/managers/EncounterManager.gd
+++ b/scripts/managers/EncounterManager.gd
@@ -254,23 +254,10 @@ func _weighted_pick(candidates: Array[EncounterConfig]) -> EncounterConfig:
 	return candidates[0]
 
 func _materialize_config(base_config: EncounterConfig, floor_index: int, is_elite: bool, is_boss: bool) -> EncounterConfig:
-	var config := EncounterConfig.new()
-	config.id = base_config.id
-	config.encounter_kind = base_config.encounter_kind
-	config.min_floor = base_config.min_floor
-	config.max_floor = base_config.max_floor
-	config.weight = base_config.weight
-	config.rows = base_config.rows
-	config.cols = base_config.cols
-	config.base_hp = base_config.base_hp
-	config.base_threat = base_config.base_threat
-	config.pattern_id = base_config.pattern_id
-	config.speed_boost_chance = base_config.speed_boost_chance
-	config.speed_boost = base_config.speed_boost
+	var config := base_config.duplicate() as EncounterConfig
+	if config == null:
+		config = EncounterConfig.new()
 	config.is_boss = base_config.is_boss or is_boss
-	config.boss_core = base_config.boss_core
-	config.boss_core_hp_bonus = base_config.boss_core_hp_bonus
-	config.variant_policy = base_config.variant_policy
 
 	if config.pattern_id == "auto":
 		config.pattern_id = _pick_pattern(floor_index, config.is_boss)


### PR DESCRIPTION
## Summary
- consolidate encounter setup into a shared helper for boss/combat flows
- use EncounterConfig duplication to reduce manual field copying

## Testing
- not run (TestLab Start Boss exercises the refactored path)