### PR TITLE
Make TestLab a first-class panel in Main

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ A single-player Godot project that fuses Breakout-style paddle/ball action with 
   - `scenes/Main.tscn`: core gameplay scene with Paddle, Bricks container, Walls, and HUD panels.
   - `scenes/Paddle.tscn`, `scenes/Ball.tscn`, `scenes/Brick.tscn`: reusable gameplay actors.
   - `scenes/MainMenu.tscn`, `scenes/Help.tscn`, `scenes/Shop.tscn`: front-end flow and shop layout.
-  - `scenes/TestLab.tscn`: debug test screen for rapid feature testing.
 - Core scripts:
   - `scripts/Main.gd`: main game controller. Owns the run state machine, deck/hand/discard, encounter setup, UI updates, and room flow (map, rewards, shop, rest, boss).
   - `scripts/Ball.gd`: ball physics, launch/bounce behavior, piercing logic, and loss handling.

--- a/data/encounters/boss_basic.tres
+++ b/data/encounters/boss_basic.tres
@@ -1,5 +1,4 @@
 [gd_resource type="Resource" load_steps=3 format=3]
-# TODO: Act Configuration
 
 [ext_resource type="Script" path="res://scripts/data/EncounterConfig.gd" id=1]
 [ext_resource type="Resource" path="res://data/variant_policies/variant_boss.tres" id=2]

--- a/data/encounters/combat_early.tres
+++ b/data/encounters/combat_early.tres
@@ -1,5 +1,4 @@
 [gd_resource type="Resource" load_steps=3 format=3]
-# TODO: Act Configuration
 
 [ext_resource type="Script" path="res://scripts/data/EncounterConfig.gd" id=1]
 [ext_resource type="Resource" path="res://data/variant_policies/variant_normal.tres" id=2]

--- a/data/encounters/combat_late.tres
+++ b/data/encounters/combat_late.tres
@@ -1,5 +1,4 @@
 [gd_resource type="Resource" load_steps=3 format=3]
-# TODO: Act Configuration
 
 [ext_resource type="Script" path="res://scripts/data/EncounterConfig.gd" id=1]
 [ext_resource type="Resource" path="res://data/variant_policies/variant_normal.tres" id=2]

--- a/data/encounters/combat_mid.tres
+++ b/data/encounters/combat_mid.tres
@@ -1,5 +1,4 @@
 [gd_resource type="Resource" load_steps=3 format=3]
-# TODO: Act Configuration
 
 [ext_resource type="Script" path="res://scripts/data/EncounterConfig.gd" id=1]
 [ext_resource type="Resource" path="res://data/variant_policies/variant_normal.tres" id=2]

--- a/data/encounters/elite_basic.tres
+++ b/data/encounters/elite_basic.tres
@@ -1,5 +1,4 @@
 [gd_resource type="Resource" load_steps=3 format=3]
-# TODO: Act Configuration
 
 [ext_resource type="Script" path="res://scripts/data/EncounterConfig.gd" id=1]
 [ext_resource type="Resource" path="res://data/variant_policies/variant_elite.tres" id=2]

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=9 format=3 uid="uid://dhnntcfxs4lg0"]
+[gd_scene load_steps=8 format=3 uid="uid://dhnntcfxs4lg0"]
 
 [ext_resource type="PackedScene" path="res://scenes/Paddle.tscn" id="1"]
 [ext_resource type="Script" uid="uid://b8nul2np1du6b" path="res://scripts/Main.gd" id="3"]
 [ext_resource type="PackedScene" uid="uid://cfnto8it2e26m" path="res://scenes/Shop.tscn" id="4"]
 [ext_resource type="Script" uid="uid://bncgwbo12t5vj" path="res://scripts/ui/MapGraph.gd" id="5"]
-[ext_resource type="PackedScene" path="res://scenes/TestLabPanel.tscn" id="6"]
 
 [sub_resource type="RectangleShape2D" id="1"]
 size = Vector2(20, 600)
@@ -50,8 +49,6 @@ position = Vector2(400, -10)
 shape = SubResource("2")
 
 [node name="HUD" type="CanvasLayer" parent="."]
-
-[node name="TestLabPanel" parent="HUD" instance=ExtResource("6")]
 
 [node name="TopBar" type="HBoxContainer" parent="HUD"]
 anchors_preset = 10

--- a/scenes/TestLabPanel.tscn
+++ b/scenes/TestLabPanel.tscn
@@ -9,6 +9,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 script = ExtResource("1")
 
 [node name="ToggleDebug" type="Button" parent="."]
@@ -29,6 +30,7 @@ offset_top = 64.0
 offset_right = 430.0
 offset_bottom = -207.0
 grow_vertical = 2
+mouse_filter = 0
 
 [node name="VBox" type="VBoxContainer" parent="DebugPanel"]
 layout_mode = 0

--- a/scripts/App.gd
+++ b/scripts/App.gd
@@ -35,6 +35,7 @@ var _settings_vfx_enabled: bool = true
 var _settings_vfx_intensity: float = 1.0
 var _settings_ball_speed_multiplier: float = 1.0
 var _settings_paddle_speed_multiplier: float = 1.0
+var _test_lab_unlocked: bool = false
 
 func _ready() -> void:
 	_ui_particle_rng.randomize()
@@ -69,6 +70,12 @@ func _action_has_key(action: String, keycode: int) -> bool:
 func has_run() -> bool:
 	return run_instance != null and is_instance_valid(run_instance)
 
+func set_test_lab_unlocked(unlocked: bool) -> void:
+	_test_lab_unlocked = unlocked
+
+func is_test_lab_unlocked() -> bool:
+	return _test_lab_unlocked
+
 func start_new_run(seed_value: int = 0) -> void:
 	if run_instance and is_instance_valid(run_instance):
 		run_instance.queue_free()
@@ -76,7 +83,10 @@ func start_new_run(seed_value: int = 0) -> void:
 	if run_instance.has_method("set_pending_seed"):
 		run_instance.set_pending_seed(seed_value)
 	if run_instance.has_method("set_test_lab_enabled"):
-		run_instance.set_test_lab_enabled(false)
+		if _test_lab_unlocked:
+			run_instance.set_test_lab_enabled(true, false)
+		else:
+			run_instance.set_test_lab_enabled(false)
 	get_tree().root.add_child(run_instance)
 	if run_instance.has_method("on_menu_closed"):
 		run_instance.on_menu_closed()
@@ -117,7 +127,7 @@ func show_test_lab() -> void:
 	run_instance = RUN_SCENE.instantiate()
 	get_tree().root.add_child(run_instance)
 	if run_instance.has_method("set_test_lab_enabled"):
-		run_instance.set_test_lab_enabled(true)
+		run_instance.set_test_lab_enabled(true, true)
 	if run_instance.has_method("on_menu_closed"):
 		run_instance.on_menu_closed()
 	_switch_to_scene(run_instance)

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -27,6 +27,7 @@ const FLOOR_PLAN_GENERATOR_CONFIG := preload("res://scripts/data/FloorPlanGenera
 const BALANCE_DATA_PATH: String = "res://data/balance/basic.tres"
 const EMOJI_FONT_PATH: String = "res://assets/fonts/NotoColorEmoji.ttf"
 const OUTCOME_PARTICLE_SCENE: PackedScene = preload("res://scenes/HitParticle.tscn")
+const TEST_LAB_PANEL_SCENE: PackedScene = preload("res://scenes/TestLabPanel.tscn")
 const OUTCOME_PARTICLE_COUNT: int = 18
 const OUTCOME_PARTICLE_SPEED_X: Vector2 = Vector2(-80.0, 80.0)
 const OUTCOME_PARTICLE_SPEED_Y_VICTORY: Vector2 = Vector2(-220.0, -60.0)
@@ -88,7 +89,6 @@ const VOLLEY_PROMPT_OFFSET_Y: float = -70.0
 @onready var restart_button: Button = $HUD/GameOverPanel/RestartButton
 @onready var menu_button: Button = $HUD/GameOverPanel/MenuButton
 @onready var forfeit_dialog: ConfirmationDialog = $HUD/ForfeitDialog
-@onready var test_lab_panel: Control = $HUD/TestLabPanel
 @onready var left_wall: CollisionShape2D = $Walls/LeftWall
 @onready var right_wall: CollisionShape2D = $Walls/RightWall
 @onready var top_wall: CollisionShape2D = $Walls/TopWall
@@ -106,6 +106,7 @@ var map_preview_active: bool = false
 var map_preview_state: int = GameState.MAP
 var treasure_reward_entries: Array[Dictionary] = []
 var test_lab_enabled: bool = false
+var test_lab_panel: Control = null
 
 var encounter_manager: EncounterManager
 var map_manager: MapManager
@@ -280,14 +281,24 @@ func _ready() -> void:
 	_set_hud_tooltips()
 	_start_run()
 
-func set_test_lab_enabled(enabled: bool) -> void:
+func set_test_lab_enabled(enabled: bool, panel_visible: bool = true) -> void:
 	test_lab_enabled = enabled
-	_set_test_lab_enabled(enabled)
+	_set_test_lab_enabled(enabled, panel_visible)
 
-func _set_test_lab_enabled(enabled: bool) -> void:
-	if test_lab_panel == null:
+func _set_test_lab_enabled(enabled: bool, panel_visible: bool = true) -> void:
+	if enabled:
+		if test_lab_panel == null or not is_instance_valid(test_lab_panel):
+			test_lab_panel = TEST_LAB_PANEL_SCENE.instantiate()
+			if test_lab_panel.has_method("set_initial_debug_panel_visible"):
+				test_lab_panel.set_initial_debug_panel_visible(panel_visible)
+		if test_lab_panel and test_lab_panel.get_parent() == null and hud:
+			hud.add_child(test_lab_panel)
+		if test_lab_panel:
+			test_lab_panel.visible = true
 		return
-	test_lab_panel.visible = enabled
+	if test_lab_panel and is_instance_valid(test_lab_panel):
+		test_lab_panel.queue_free()
+	test_lab_panel = null
 
 func set_pending_seed(seed_value: int) -> void:
 	pending_seed = seed_value

--- a/scripts/MainMenu.gd
+++ b/scripts/MainMenu.gd
@@ -56,6 +56,7 @@ func _unhandled_input(event: InputEvent) -> void:
 
 func _lock_test_lab() -> void:
 	test_lab_unlocked = false
+	App.set_test_lab_unlocked(false)
 	if test_button:
 		test_button.visible = false
 
@@ -66,6 +67,7 @@ func _try_unlock_test_lab(event: InputEventKey) -> void:
 		return
 	if event.keycode == KEY_T and event.alt_pressed and event.ctrl_pressed and event.shift_pressed:
 		test_lab_unlocked = true
+		App.set_test_lab_unlocked(true)
 		test_button.visible = true
 		_apply_menu_palette()
 

--- a/scripts/TestLab.gd
+++ b/scripts/TestLab.gd
@@ -3,10 +3,13 @@ extends Control
 var main: Node = null
 @onready var debug_panel: Control = $DebugPanel
 @onready var toggle_button: Button = $ToggleDebug
+var initial_debug_panel_visible: bool = true
 
 func _ready() -> void:
 	_apply_debug_font_size(9)
 	_apply_debug_theme()
+	if debug_panel:
+		debug_panel.visible = initial_debug_panel_visible
 	_update_toggle_button_text()
 	_connect_button("ToggleDebug", _toggle_debug_panel)
 	resized.connect(_layout_toggle_button)
@@ -135,6 +138,17 @@ func _toggle_debug_panel() -> void:
 		return
 	debug_panel.visible = not debug_panel.visible
 	_update_toggle_button_text()
+
+func set_debug_panel_visible(visible: bool) -> void:
+	if debug_panel == null:
+		return
+	debug_panel.visible = visible
+	_update_toggle_button_text()
+
+func set_initial_debug_panel_visible(visible: bool) -> void:
+	initial_debug_panel_visible = visible
+	if is_node_ready():
+		set_debug_panel_visible(visible)
 
 func _update_toggle_button_text() -> void:
 	if toggle_button == null or debug_panel == null:


### PR DESCRIPTION
Closes #89

Summary
- Make TestLab a panel inside Main instead of wrapping Main.
- Show TestLab via App.show_test_lab() by enabling the panel on a normal run.
- Keep a lightweight TestLab scene that just instances the panel.
