### PR TITLE
Update ball and paddle visuals

### DIFF
--- a/scenes/Ball.tscn
+++ b/scenes/Ball.tscn
@@ -2,8 +2,8 @@
 
 [ext_resource type="Script" path="res://scripts/Ball.gd" id=1]
 
-[sub_resource type="RectangleShape2D" id=1]
-size = Vector2(16, 16)
+[sub_resource type="CircleShape2D" id=1]
+radius = 8.0
 
 [node name="Ball" type="CharacterBody2D"]
 script = ExtResource("1")
@@ -15,6 +15,7 @@ shape = SubResource("1")
 position = Vector2(-8, -8)
 size = Vector2(16, 16)
 color = Color(0.95, 0.95, 1, 1)
+visible = false
 
 [node name="BounceSfx" type="AudioStreamPlayer" parent="."]
 volume_db = -8.0

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -27,7 +27,7 @@ anchor_bottom = 1.0
 color = Color(0.08, 0.08, 0.1, 1)
 
 [node name="Playfield" type="Polygon2D" parent="."]
-color = Color(0.16, 0.16, 0.18, 1)
+color = Color(0.12, 0.12, 0.14, 1)
 
 [node name="Paddle" parent="." instance=ExtResource("1")]
 position = Vector2(400, 386)

--- a/scenes/Paddle.tscn
+++ b/scenes/Paddle.tscn
@@ -1,17 +1,14 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=2 format=3]
 
 [ext_resource type="Script" path="res://scripts/Paddle.gd" id=1]
-
-[sub_resource type="RectangleShape2D" id=1]
-size = Vector2(100, 16)
 
 [node name="Paddle" type="CharacterBody2D"]
 script = ExtResource("1")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource("1")
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
 
 [node name="Rect" type="ColorRect" parent="."]
-position = Vector2(-50, -8)
-size = Vector2(100, 16)
+position = Vector2(-60, -10)
+size = Vector2(120, 20)
 color = Color(0.9, 0.9, 0.9, 1)
+visible = false

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -182,10 +182,10 @@ var volley_prompt_pulsing: bool = false
 
 func _update_reserve_indicator() -> void:
 	if paddle and paddle.has_method("set_reserve_count"):
+		var count: int = volley_ball_reserve
 		if state == GameState.PLANNING:
-			paddle.set_reserve_count(volley_ball_bonus)
-		else:
-			paddle.set_reserve_count(volley_ball_reserve)
+			count += 1 + volley_ball_bonus
+		paddle.set_reserve_count(count)
 
 func _ready() -> void:
 	balance_data = load(BALANCE_DATA_PATH)
@@ -1412,6 +1412,7 @@ func _play_card(instance_id: int) -> void:
 
 func _apply_card_effect(card_id: String, instance_id: int) -> bool:
 	var should_discard := true
+	# TODO: Add card "what doesnt kill us..." (cost 1). If played with a wound, destroy that wound and gain 2 energy.
 	match card_id:
 		"punch":
 			volley_damage_bonus += 1

--- a/scripts/Paddle.gd
+++ b/scripts/Paddle.gd
@@ -1,19 +1,29 @@
 extends CharacterBody2D
 
+const GhostShape = preload("res://scripts/effects/GhostShape.gd")
+
 @export var speed: float = 420.0
-@export var half_width: float = 50.0
+@export var half_width: float = 60.0
 
 @onready var rect: ColorRect = $Rect
-@onready var collider: CollisionShape2D = $CollisionShape2D
+@onready var collider: CollisionPolygon2D = $CollisionPolygon2D
 
 var locked_y: float = 0.0
 var reserve_count: int = 0
-const RESERVE_SIZE: float = 10.0
-const RESERVE_GAP: float = 6.0
-const RESERVE_COLOR: Color = Color(1, 1, 1, 1)
+var _ghost_last_pos: Vector2 = Vector2.ZERO
+const RESERVE_SIZE: float = 6.0
+const RESERVE_GAP: float = 3.0
+const RESERVE_COLOR: Color = Color(0.05, 0.05, 0.05, 1)
+const PADDLE_COLOR: Color = Color(0.9, 0.9, 0.9, 1)
+const COLLIDER_SEGMENTS: int = 256
+const GHOST_SPACING: float = 12.0
+const GHOST_LIFETIME: float = 0.18
+const GHOST_ALPHA: float = 0.35
 
 func _ready() -> void:
 	locked_y = position.y
+	_ghost_last_pos = position
+	_update_collider_polygon()
 
 func _physics_process(_delta: float) -> void:
 	var right_strength: float = float(Input.get_action_strength("ui_right"))
@@ -28,26 +38,81 @@ func _physics_process(_delta: float) -> void:
 	var clamped_x: float = clamp(position.x, half_width, layout_width - half_width)
 	position.x = clamped_x
 	position.y = locked_y
+	_update_ghosts()
 
 func _draw() -> void:
-	if reserve_count <= 0:
+	_draw_paddle()
+	_draw_reserve()
+
+func _draw_paddle() -> void:
+	var size: Vector2 = rect.size if rect else Vector2(half_width * 2.0, 16.0)
+	var color: Color = rect.color if rect else PADDLE_COLOR
+	var half_size: Vector2 = size * 0.5
+	var points := PackedVector2Array()
+	for i in range(256):
+		var angle: float = TAU * float(i) / 256.0
+		points.append(Vector2(cos(angle) * half_size.x, sin(angle) * half_size.y))
+	var backing_points := PackedVector2Array()
+	for point in points:
+		backing_points.append(point * 1.01)
+	draw_colored_polygon(backing_points, Color(0.65, 0.65, 0.68, 1.0))
+	draw_colored_polygon(points, color)
+
+func _draw_reserve() -> void:
+	var count: int = reserve_count
+	if count <= 0:
 		return
-	var total_width: float = reserve_count * RESERVE_SIZE + max(0, reserve_count - 1) * RESERVE_GAP
+	var total_width: float = count * RESERVE_SIZE + max(0, count - 1) * RESERVE_GAP
 	var start_x: float = -total_width * 0.5
-	var y: float = -rect.size.y * 0.5 - 8.0 - RESERVE_SIZE
-	for i in range(reserve_count):
+	var y: float = -RESERVE_SIZE * 0.5
+	var radius: float = RESERVE_SIZE * 0.5
+	for i in range(count):
 		var x: float = start_x + i * (RESERVE_SIZE + RESERVE_GAP)
-		var rect_box: Rect2 = Rect2(Vector2(x, y), Vector2(RESERVE_SIZE, RESERVE_SIZE))
-		draw_rect(rect_box, RESERVE_COLOR, false, 2.0)
+		var center := Vector2(x + radius, y + radius)
+		draw_circle(center, radius, RESERVE_COLOR)
+
+func _update_ghosts() -> void:
+	if not App.get_vfx_enabled():
+		return
+	var intensity: float = App.get_vfx_intensity()
+	if intensity <= 0.0:
+		return
+	var spacing: float = GHOST_SPACING / max(0.1, intensity)
+	if _ghost_last_pos.distance_to(position) < spacing:
+		return
+	_ghost_last_pos = position
+	_spawn_ghost(intensity)
+
+func _spawn_ghost(intensity: float) -> void:
+	var parent_node := get_parent()
+	if parent_node == null:
+		return
+	var ghost := GhostShape.new()
+	ghost.position = position
+	ghost.z_index = rect.z_index if rect else 0
+	parent_node.add_child(ghost)
+	var size: Vector2 = rect.size if rect else Vector2(half_width * 2.0, 16.0)
+	var base_color: Color = rect.color if rect else PADDLE_COLOR
+	base_color.a = clampf(GHOST_ALPHA * intensity, 0.0, 1.0)
+	ghost.setup(GhostShape.SHAPE_ELLIPSE, size, base_color, GHOST_LIFETIME)
 
 func set_half_width(value: float) -> void:
 	half_width = max(20.0, value)
 	rect.size.x = half_width * 2.0
 	rect.position.x = -half_width
-	if collider.shape is RectangleShape2D:
-		var shape: RectangleShape2D = collider.shape as RectangleShape2D
-		shape.size.x = half_width * 2.0
+	_update_collider_polygon()
 	queue_redraw()
+
+func _update_collider_polygon() -> void:
+	if collider == null:
+		return
+	var size: Vector2 = rect.size if rect else Vector2(half_width * 2.0, 16.0)
+	var half_size: Vector2 = size * 0.5
+	var points := PackedVector2Array()
+	for i in range(COLLIDER_SEGMENTS):
+		var angle: float = TAU * float(i) / float(COLLIDER_SEGMENTS)
+		points.append(Vector2(cos(angle) * half_size.x, sin(angle) * half_size.y))
+	collider.polygon = points
 
 func set_locked_y(value: float) -> void:
 	locked_y = value

--- a/scripts/effects/GhostShape.gd
+++ b/scripts/effects/GhostShape.gd
@@ -1,0 +1,37 @@
+extends Node2D
+class_name GhostShape
+
+const SHAPE_CIRCLE: String = "circle"
+const SHAPE_ELLIPSE: String = "ellipse"
+
+var shape: String = SHAPE_CIRCLE
+var size: Vector2 = Vector2(16.0, 16.0)
+var _ghost_color: Color = Color(1, 1, 1, 1)
+var ghost_color: Color:
+	set(value):
+		_ghost_color = value
+		queue_redraw()
+	get:
+		return _ghost_color
+
+func setup(shape_type: String, draw_size: Vector2, color: Color, lifetime: float) -> void:
+	shape = shape_type
+	size = draw_size
+	ghost_color = color
+	queue_redraw()
+	var tween := create_tween()
+	tween.tween_property(self, "ghost_color", Color(color.r, color.g, color.b, 0.0), lifetime)
+	tween.tween_callback(queue_free)
+
+func _draw() -> void:
+	if ghost_color.a <= 0.0:
+		return
+	var height: float = max(1.0, size.y)
+	var radius: float = height * 0.5
+	if shape == SHAPE_ELLIPSE:
+		var scale_x: float = max(0.01, size.x / height)
+		draw_set_transform(Vector2.ZERO, 0.0, Vector2(scale_x, 1.0))
+		draw_circle(Vector2.ZERO, radius, ghost_color)
+		draw_set_transform(Vector2.ZERO, 0.0, Vector2.ONE)
+	else:
+		draw_circle(Vector2.ZERO, radius, ghost_color)


### PR DESCRIPTION
Closes #87
Closes #88

- Paddle: ellipse visual with polygon collider and resized to 120x20; new ghost trail + volley indicators.
- Ball: circular collider/visual with updated ghost trail.
- Playfield: darker background to improve contrast.