### PR TITLE
Bugfix: Test Lab Pass Level should advance to Act 3

### DIFF
--- a/scripts/TestLab.gd
+++ b/scripts/TestLab.gd
@@ -153,6 +153,9 @@ func _ready() -> void:
 	)
 	_connect_button("DebugPanel/VBox/ButtonColumns/RightColumn/PassLevel", func() -> void:
 		_with_main(func(main_node: Node) -> void:
+			if main_node.has_method("test_lab_pass_level"):
+				main_node.call("test_lab_pass_level")
+				return
 			for child in main_node.bricks_root.get_children():
 				child.queue_free()
 			main_node._end_encounter()


### PR DESCRIPTION
Fixes #132.

What was happening:
- The Test Lab 'Pass Level' button directly called Main._end_encounter() after clearing bricks.
- If pressed while the run was in GAME_OVER, the boss completion path attempted to transition via advance_act (not allowed from GAME_OVER), and brick clearing could also make encounter_manager.check_victory() true, triggering the GAME_OVER auto-victory handler.

What this changes:
- Adds Main.test_lab_pass_level() and routes the Test Lab button through it.
- If 'Pass Level' is used while in GAME_OVER/VICTORY, it forces state back into a safe run state (PLANNING with resume=true) before calling _end_encounter(), so advance_act is allowed.
- Adds an _end_encounter_in_progress guard and uses it to suppress the GAME_OVER auto-victory check while an encounter is ending.

Test plan:
- Test Lab: reach Act 2 boss, die to show Game Over, press 'Pass Level' => advances to Act 3 map.
- Normal run: defeating Act 1/2 bosses still advances acts as before.

Closes #132.