### PR TITLE
Fix: clear ball mod after post-victory drop

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -1137,6 +1137,10 @@ func _begin_encounter(is_elite: bool, is_boss: bool) -> void:
 	_hide_all_panels()
 	_clear_all_balls_for_new_layout()
 	post_clear_catch_active = false
+	if not _is_persist_enabled():
+		active_ball_mod = ""
+		_apply_ball_mod_to_active_balls()
+		_refresh_mod_buttons()
 	current_is_elite = is_elite
 	encounter_has_launched = false
 	App.stop_rest_music()

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -1268,6 +1268,10 @@ func _on_ball_lost(ball: Node) -> void:
 	if is_instance_valid(ball):
 		ball.queue_free()
 	if post_clear_catch_active:
+		if active_balls.is_empty() and not _is_persist_enabled():
+			active_ball_mod = ""
+			_apply_ball_mod_to_active_balls()
+			_refresh_mod_buttons()
 		return
 	encounter_manager.regen_bricks_on_drop()
 	if current_is_boss and encounter_manager:

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -1272,10 +1272,6 @@ func _on_ball_lost(ball: Node) -> void:
 	if is_instance_valid(ball):
 		ball.queue_free()
 	if post_clear_catch_active:
-		if active_balls.is_empty() and not _is_persist_enabled():
-			active_ball_mod = ""
-			_apply_ball_mod_to_active_balls()
-			_refresh_mod_buttons()
 		return
 	encounter_manager.regen_bricks_on_drop()
 	if current_is_boss and encounter_manager:


### PR DESCRIPTION
Closes #151.

When an encounter ends while a ball is still active, letting that ball drop later runs through `_on_ball_lost()` with `post_clear_catch_active` set. Previously, that early-return path skipped clearing the selected ball mod, so it could incorrectly remain active into the next encounter.

This change clears `active_ball_mod` when the last post-victory ball is dropped and Persist is off.
